### PR TITLE
Adding first bits for multiple data listeners

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -278,7 +278,6 @@ func messageHandler(endpoint Endpoint, deliveries <-chan amqp.Delivery) {
 			close(event.Success)
 			close(event.Failure)
 			close(event.Skip)
-			event.Skip <- true
 		}()
 
 		for _, listener := range endpoint.dataListeners {

--- a/event.go
+++ b/event.go
@@ -1,11 +1,15 @@
 package remit
 
 import (
+	"sync"
+
 	"github.com/streadway/amqp"
 )
 
 type Event struct {
-	message amqp.Delivery
+	message   amqp.Delivery
+	waitGroup *sync.WaitGroup
+	gotResult bool
 
 	EventId   string
 	EventType string
@@ -14,6 +18,7 @@ type Event struct {
 
 	Success chan interface{}
 	Failure chan interface{}
+	Skip    chan bool
 }
 
 type EventData map[string]interface{}

--- a/event.go
+++ b/event.go
@@ -18,7 +18,7 @@ type Event struct {
 
 	Success chan interface{}
 	Failure chan interface{}
-	Skip    chan bool
+	Next    chan bool
 }
 
 type EventData map[string]interface{}

--- a/remit.go
+++ b/remit.go
@@ -6,7 +6,10 @@ import (
 	"sync"
 
 	"github.com/streadway/amqp"
+	. "github.com/tj/go-debug"
 )
+
+var debug = Debug("remit")
 
 type ConnectionOptions struct {
 	Url  string
@@ -14,6 +17,8 @@ type ConnectionOptions struct {
 }
 
 func Connect(options ConnectionOptions) Session {
+	debug("connecting to amq")
+
 	conn, err := amqp.Dial(options.Url)
 	failOnError(err, "Failed to connect to RabbitMQ")
 

--- a/session.go
+++ b/session.go
@@ -78,11 +78,10 @@ func logClosure() {
 	log.Println("      Cancelling again will initiate a cold shutdown and messages may be lost.")
 }
 
-func (session *Session) Endpoint(key string, handler EndpointDataHandler) Endpoint {
+func (session *Session) Endpoint(key string) Endpoint {
 	endpoint := createEndpoint(session, EndpointOptions{
-		RoutingKey:  key,
-		Queue:       key,
-		DataHandler: handler,
+		RoutingKey: key,
+		Queue:      key,
 	})
 
 	return endpoint


### PR DESCRIPTION
This will be the PR for #3.

We've got it to a stage where registering data listeners works, but we need a way for data listeners to not return either `Success` or `Failure`. A `Skip` channel might be valuable here.

Most importantly, the current `handleData` function will wait for all endpoint listeners (`Success` and `Failure`) to return, meaning that if one listener returns success after 1 second and another after 2 seconds, the latter would still wait the full two seconds.

We'll need a thread-safe way to determine if `Success` or `Failure` has been returned by some other listener. If that is the case our best bet is to ignore any other responses coming in (and cancel any further action as soon as it happens).