### PR TITLE
Requests

### DIFF
--- a/emit.go
+++ b/emit.go
@@ -1,0 +1,71 @@
+package remit
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/streadway/amqp"
+)
+
+type Emit struct {
+	session *Session
+	Channel chan interface{}
+
+	RoutingKey string
+}
+
+type EmitOptions struct {
+	RoutingKey string
+}
+
+func createEmission(session *Session, options EmitOptions) Emit {
+	emit := Emit{
+		RoutingKey: options.RoutingKey,
+		session:    session,
+		Channel:    make(chan interface{}),
+	}
+
+	go emit.waitForEmissions()
+
+	return emit
+}
+
+func (emit *Emit) waitForEmissions() {
+	for data := range emit.Channel {
+		debug("got emission")
+
+		emit.send(data)
+	}
+
+	fmt.Println("finished")
+}
+
+func (emit *Emit) send(data interface{}) {
+	emit.session.waitGroup.Add(1)
+	defer emit.session.waitGroup.Done()
+
+	message := amqp.Publishing{
+		Headers:     amqp.Table{},
+		ContentType: "application/json",
+		Timestamp:   time.Now(),
+		MessageId:   ulid.MustNew(ulid.Now(), nil).String(),
+		AppId:       emit.session.Config.Name,
+	}
+
+	if data != nil {
+		j, err := json.Marshal(data)
+		failOnError(err, "Failed making JSON from result")
+		message.Body = j
+	}
+
+	err := emit.session.publishChannel.Publish(
+		"remit",         // exchange
+		emit.RoutingKey, // routing key / queue
+		false,           // mandatory
+		false,           // immediate
+		message,         // amqp.Publishing
+	)
+	failOnError(err, "Failed to send emit message")
+}

--- a/event.go
+++ b/event.go
@@ -7,14 +7,16 @@ import (
 )
 
 type Event struct {
-	message   amqp.Delivery
-	waitGroup *sync.WaitGroup
-	gotResult bool
+	message     amqp.Delivery
+	waitGroup   *sync.WaitGroup
+	gotResult   bool
+	workChannel chan *amqp.Channel
 
 	EventId   string
 	EventType string
 	Resource  string
 	Data      EventData
+	Error     interface{}
 
 	Success chan interface{}
 	Failure chan interface{}

--- a/remit.go
+++ b/remit.go
@@ -111,10 +111,8 @@ func Connect(options ConnectionOptions) Session {
 		waitGroup:     &sync.WaitGroup{},
 		mu:            &sync.Mutex{},
 		awaitingReply: replyList,
-		workers:       make(chan *amqp.Channel, 1),
+		workerPool:    newWorkerPool(1, 5, conn),
 	}
-
-	go session.startGeneratingWorkers()
 
 	return session
 }

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ type Session struct {
 	connection     *amqp.Connection
 	publishChannel *amqp.Channel
 	requestChannel *amqp.Channel
-	awaitingReply  map[string]RequestDataHandler
+	awaitingReply  map[string]chan Event
 
 	waitGroup *sync.WaitGroup
 	mu        *sync.Mutex
@@ -157,14 +157,13 @@ func (session *Session) Emit(key string, data interface{}) {
 	failOnError(err, "Failed to emit message")
 }
 
-func (session *Session) Request(key string, data interface{}, handler RequestDataHandler) Request {
+func (session *Session) Request(key string, data interface{}) chan Event {
 	request := createRequest(session, RequestOptions{
-		RoutingKey:  key,
-		DataHandler: handler,
-		Data:        data,
+		RoutingKey: key,
+		Data:       data,
 	})
 
-	return request
+	return request.returnChannel
 }
 
 func (session *Session) Listener(key string) Endpoint {

--- a/session.go
+++ b/session.go
@@ -16,7 +16,7 @@ type Session struct {
 	publishChannel *amqp.Channel
 	requestChannel *amqp.Channel
 	awaitingReply  map[string]chan Event
-	workers        chan *amqp.Channel
+	workerPool     *workerPool
 
 	waitGroup *sync.WaitGroup
 	mu        *sync.Mutex
@@ -28,15 +28,6 @@ type Session struct {
 
 func (session *Session) registerReply(correlationId string, returnChannel chan Event) {
 	session.awaitingReply[correlationId] = returnChannel
-}
-
-func (session *Session) startGeneratingWorkers() {
-	for {
-		log.Println("creating new worker channel")
-		channel, err := session.connection.Channel()
-		failOnError(err, "failed to generate worker")
-		session.workers <- channel
-	}
 }
 
 func (session *Session) CloseOnSignal() chan bool {

--- a/workerPool.go
+++ b/workerPool.go
@@ -1,0 +1,96 @@
+package remit
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/streadway/amqp"
+)
+
+type workerPool struct {
+	mx         *sync.Mutex
+	min        int
+	max        int
+	channels   chan *amqp.Channel
+	count      int
+	inuse      int
+	connection *amqp.Connection
+}
+
+func newWorkerPool(min int, max int, connection *amqp.Connection) *workerPool {
+	p := &workerPool{
+		min:        min,
+		max:        max,
+		channels:   make(chan *amqp.Channel, max),
+		connection: connection,
+		mx:         &sync.Mutex{},
+	}
+
+	for i := 0; i < p.min; i++ {
+		p.new()
+	}
+
+	return p
+}
+
+func (p *workerPool) new() {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	p.count++
+	channel := p.create()
+	p.channels <- channel
+}
+
+func (p *workerPool) create() *amqp.Channel {
+	fmt.Println("creating work channel")
+	channel, _ := p.connection.Channel()
+	return channel
+}
+
+func (p *workerPool) Get() *amqp.Channel {
+waiting:
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	if p.inuse < p.count {
+		p.inuse++
+	} else if p.count < p.max {
+		channel := p.create()
+		p.channels <- channel
+		p.count++
+		p.inuse++
+	} else {
+		p.mx.Unlock()
+		goto waiting
+	}
+
+	if p.count < p.min {
+		go p.new()
+	}
+
+	return <-p.channels
+}
+
+func (p *workerPool) Release(channel *amqp.Channel) {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	if (p.count - p.inuse) > p.min {
+		p.Drop(channel)
+		p.count--
+	} else {
+		p.channels <- channel
+	}
+
+	p.inuse--
+}
+
+func (p *workerPool) Drop(channel *amqp.Channel) {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	channel.Close()
+	p.count--
+	p.inuse--
+}


### PR DESCRIPTION
In it's current state, even our worker channel pool is pretty sluggish.
We're still making a new channel for each request; the worker pool is a good idea, but we need to be able to re-use existing worker channels for speediness.